### PR TITLE
feat: add sitemap

### DIFF
--- a/e2e-tests/sitemap.spec.ts
+++ b/e2e-tests/sitemap.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Sitemap", () => {
+  test("should be accessible and have the correct content type", async ({
+    request,
+  }) => {
+    const response = await request.get("/sitemap.xml");
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toBe("application/xml");
+  });
+
+  test("should contain the main pages", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const sitemap = await response.text();
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/about</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/blog</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/bookshelf</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/contact</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/now</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/privacy</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/projects</loc>");
+    expect(sitemap).toContain("<loc>https://josimar-silva.com/terms</loc>");
+  });
+
+  test("should contain blog posts", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const sitemap = await response.text();
+    expect(sitemap).toContain(
+      "<loc>https://josimar-silva.com/blog/2025-01-21-rinha-de-backend-2025</loc>",
+    );
+  });
+});

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,55 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Josimar Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { getAllPosts } from "@/lib/posts";
+
+import sitemap from "./sitemap";
+
+jest.mock("@/lib/posts");
+
+describe("sitemap", () => {
+  it("should generate the correct sitemap", async () => {
+    const mockPosts = [
+      { slug: "post-1", date: "2025-01-01" },
+      { slug: "post-2", date: "2025-01-02" },
+    ];
+    (getAllPosts as jest.Mock).mockResolvedValue(mockPosts);
+
+    const result = await sitemap();
+
+    expect(result).toHaveLength(11); // 9 static pages + 2 posts
+    expect(result).toContainEqual({
+      url: "https://josimar-silva.com/blog/post-1",
+      lastModified: new Date("2025-01-01"),
+    });
+    expect(result).toContainEqual({
+      url: "https://josimar-silva.com/blog/post-2",
+      lastModified: new Date("2025-01-02"),
+    });
+    expect(result).toContainEqual({
+      url: "https://josimar-silva.com/",
+      lastModified: expect.any(Date),
+    });
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,54 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Josimar Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { MetadataRoute } from "next";
+
+import { getAllPosts } from "@/lib/posts";
+
+export const dynamic = "force-static";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://josimar-silva.com";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPosts(["slug", "date"]);
+
+  const postUrls = posts.map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+  }));
+
+  const staticPages = [
+    { url: `${siteUrl}/`, lastModified: new Date() },
+    { url: `${siteUrl}/about`, lastModified: new Date() },
+    { url: `${siteUrl}/blog`, lastModified: new Date() },
+    { url: `${siteUrl}/bookshelf`, lastModified: new Date() },
+    { url: `${siteUrl}/contact`, lastModified: new Date() },
+    { url: `${siteUrl}/now`, lastModified: new Date() },
+    { url: `${siteUrl}/privacy`, lastModified: new Date() },
+    { url: `${siteUrl}/projects`, lastModified: new Date() },
+    { url: `${siteUrl}/terms`, lastModified: new Date() },
+  ];
+
+  return [...staticPages, ...postUrls];
+}


### PR DESCRIPTION
Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a sitemap at /sitemap.xml that lists key site pages and blog posts with last modified dates, improving SEO and discoverability. Served as application/xml.

- Tests
  - Added end-to-end tests to confirm the sitemap is accessible, correctly typed, and includes expected URLs.
  - Added unit tests to validate sitemap generation logic for static pages and blog posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->