### PR TITLE
feat(bookshelf): add individual book pages to sitemap

### DIFF
--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -22,11 +22,13 @@
  * SOFTWARE.
  */
 
+import { getBooks } from "@/lib/books";
 import { getAllPosts } from "@/lib/posts";
 
 import sitemap from "./sitemap";
 
 jest.mock("@/lib/posts");
+jest.mock("@/lib/books");
 
 describe("sitemap", () => {
   it("should generate the correct sitemap", async () => {
@@ -34,11 +36,16 @@ describe("sitemap", () => {
       { slug: "post-1", date: "2025-01-01" },
       { slug: "post-2", date: "2025-01-02" },
     ];
+    const mockBooks = [
+      { slug: "book-1", dateRead: "2025-01-15" },
+      { slug: "book-2", dateRead: "2025-01-20" },
+    ];
     (getAllPosts as jest.Mock).mockResolvedValue(mockPosts);
+    (getBooks as jest.Mock).mockResolvedValue(mockBooks);
 
     const result = await sitemap();
 
-    expect(result).toHaveLength(11); // 9 static pages + 2 posts
+    expect(result).toHaveLength(13); // 9 static pages + 2 posts + 2 books
     expect(result).toContainEqual({
       url: "https://josimar-silva.com/blog/post-1",
       lastModified: new Date("2025-01-01"),
@@ -46,6 +53,14 @@ describe("sitemap", () => {
     expect(result).toContainEqual({
       url: "https://josimar-silva.com/blog/post-2",
       lastModified: new Date("2025-01-02"),
+    });
+    expect(result).toContainEqual({
+      url: "https://josimar-silva.com/bookshelf/book-1",
+      lastModified: new Date("2025-01-15"),
+    });
+    expect(result).toContainEqual({
+      url: "https://josimar-silva.com/bookshelf/book-2",
+      lastModified: new Date("2025-01-20"),
     });
     expect(result).toContainEqual({
       url: "https://josimar-silva.com/",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,6 +24,7 @@
 
 import { MetadataRoute } from "next";
 
+import { getBooks } from "@/lib/books";
 import { getAllPosts } from "@/lib/posts";
 
 export const dynamic = "force-static";
@@ -32,10 +33,16 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://josimar-silva.com";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await getAllPosts(["slug", "date"]);
+  const books = await getBooks();
 
   const postUrls = posts.map((post) => ({
     url: `${siteUrl}/blog/${post.slug}`,
     lastModified: new Date(post.date),
+  }));
+
+  const bookUrls = books.map((book) => ({
+    url: `${siteUrl}/bookshelf/${book.slug}`,
+    lastModified: new Date(book.dateRead),
   }));
 
   const staticPages = [
@@ -50,5 +57,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${siteUrl}/terms`, lastModified: new Date() },
   ];
 
-  return [...staticPages, ...postUrls];
+  return [...staticPages, ...postUrls, ...bookUrls];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sitemap now includes bookshelf entries (book pages) alongside posts and static pages for better discoverability.

* **Tests**
  * Sitemap tests updated to verify bookshelf entries are present and counted in the sitemap results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->